### PR TITLE
Use glusterrest to create volumes in the remote cluster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ See this video for a slightly longer usage explanation:
 
 https://youtu.be/SVtsT9WVujs
 
+### Volume creation on demand
+
+This extension can create volumes on the remote cluster if you install https://github.com/aravindavk/glusterfs-rest in one of the nodes of the cluster.
+
+You need to set two extra flags when you start the extension if you want to let containers to create their volumes on demand:
+
+- rest: is the URL address to the remote api.
+- gfs-base: is the base path where the volumes will be created.
+
+This is an example of the command line to start the plugin:
+
+```
+$ docker-volume-glusterfs -servers gfs-1:gfs2 \
+    -rest http://gfs-1:9000 -gfs-base /var/lib/gluster/volumes
+```
+
+These volumes are replicated among all the peers in the cluster that you specify in the `-servers` flag.
 
 ## LICENSE
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ const (
 var (
 	defaultDir  = filepath.Join(dkvolume.DefaultDockerRootDirectory, glusterfsId)
 	serversList = flag.String("servers", "", "List of glusterfs servers")
+	restAddress = flag.String("rest", "", "URL to glusterfsrest api")
+	gfsBase     = flag.String("gfs-base", "/mnt/gfs", "Base directory where volumes are created in the cluster")
 	root        = flag.String("root", defaultDir, "GlusterFS volumes root directory")
 )
 
@@ -35,7 +37,7 @@ func main() {
 
 	servers := strings.Split(*serversList, ":")
 
-	d := newGlusterfsDriver(*root, servers)
+	d := newGlusterfsDriver(*root, *restAddress, *gfsBase, servers)
 	h := dkvolume.NewHandler(d)
 	fmt.Printf("listening on %s\n", socketAddress)
 	fmt.Println(h.ServeUnix("root", socketAddress))

--- a/rest/client.go
+++ b/rest/client.go
@@ -1,0 +1,147 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	volumesPath      = "/api/1.0/volumes"
+	volumeCreatePath = "/api/1.0/volume/%s"
+	volumeStopPath   = "/api/1.0/volume/%s/stop"
+)
+
+type peer struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type volume struct {
+	Name       string `json:"name"`
+	Uuid       string `json:"uuid"`
+	Type       string `json:"type"`
+	Status     string `json:"status"`
+	NumBricks  int    `json:"num_bricks"`
+	Distribute int    `json:"distribute"`
+	Stripe     int    `json:"stripe"`
+	Replica    int    `json:"replica"`
+	Transport  string `json:"transport"`
+}
+
+type response struct {
+	Ok  bool   `json:"ok"`
+	Err string `json:"error,omitempty"`
+}
+
+type peerResponse struct {
+	Data []peer `json:"data",omitempty`
+	response
+}
+
+type volumeResponse struct {
+	Data []volume `json:"data",omitempty`
+	response
+}
+
+type Client struct {
+	addr string
+	base string
+}
+
+func NewClient(addr, base string) *Client {
+	return &Client{addr, base}
+}
+
+func (r Client) VolumeExist(name string) (bool, error) {
+	vols, err := r.volumes()
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range vols {
+		if v.Name == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r Client) volumes() ([]volume, error) {
+	u := fmt.Sprintf("%s%s", r.addr, volumesPath)
+
+	res, err := http.Get(u)
+	if err != nil {
+		return nil, err
+	}
+
+	var d volumeResponse
+	if err := json.NewDecoder(res.Body).Decode(&d); err != nil {
+		return nil, err
+	}
+
+	if !d.Ok {
+		return nil, fmt.Errorf(d.Err)
+	}
+	return d.Data, nil
+}
+
+func (r Client) CreateVolume(name string, peers []string) error {
+	u := fmt.Sprintf("%s%s", r.addr, fmt.Sprintf(volumeCreatePath, name))
+	fmt.Println(u)
+
+	bricks := make([]string, len(peers))
+	for i, p := range peers {
+		bricks[i] = fmt.Sprintf("%s:%s", p, filepath.Join(r.base, name))
+	}
+
+	params := url.Values{
+		"bricks":    {strings.Join(bricks, ",")},
+		"replica":   {strconv.Itoa(len(peers))},
+		"transport": {"tcp"},
+		"start":     {"true"},
+		"force":     {"true"},
+	}
+
+	resp, err := http.PostForm(u, params)
+	if err != nil {
+		return err
+	}
+
+	return responseCheck(resp)
+}
+
+func (r Client) StopVolume(name string) error {
+	u := fmt.Sprintf("%s%s", r.addr, fmt.Sprintf(volumeStopPath, name))
+
+	req, err := http.NewRequest("PUT", u, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return responseCheck(resp)
+}
+
+func responseCheck(resp *http.Response) error {
+	var p response
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		return err
+	}
+
+	if !p.Ok {
+		return fmt.Errorf(p.Err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Create volumes on demand when a container starts.
Use https://github.com/aravindavk/glusterfs-rest as remote api in the GlusterFS cluster.

Add two new flags to the cli:
- rest: URL address when the remote api is. Set the admin/root credentials in the address. For example:

```
$ docker-gluster -rest http://glusteradmin:foobar@gfs-server-1:9000
```
- gfs-base: base directory where the volumes are created in the cluster. /mnt/gfs by default. For example:

```
$ docker-glusterfs -gfs-base /mnt/gfs_block
```

Signed-off-by: David Calavera david.calavera@gmail.com
