### PR TITLE
remove debug loglevel to stop spammy logs

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -152,7 +152,7 @@ func (d *glusterfsDriver) mountVolume(name, destination string) error {
 		serverNodes = append(serverNodes, fmt.Sprintf("-s %s", server))
 	}
 
-	cmd := fmt.Sprintf("glusterfs --log-level=DEBUG --volfile-id=%s %s %s", name, strings.Join(serverNodes[:], " "), destination)
+	cmd := fmt.Sprintf("glusterfs --volfile-id=%s %s %s", name, strings.Join(serverNodes[:], " "), destination)
 	if out, err := exec.Command("sh", "-c", cmd).CombinedOutput(); err != nil {
 		log.Println(string(out))
 		return err


### PR DESCRIPTION
Hi,
Just a simple PR to disable "debug" loglevel on glusterfs client to avoid to have my disks full of logs ;)
Thx,
