### PR TITLE
added basic Capabilities function to the driver

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -189,3 +189,9 @@ func (d *glusterfsDriver) unmountVolume(target string) error {
 	}
 	return nil
 }
+
+func (d glusterfsDriver) Capabilities(r volume.Request) volume.Response {
+    var res volume.Response
+    res.Capabilities = volume.Capability{Scope: "local"}
+    return res
+}


### PR DESCRIPTION
This commit fixes the following compile error for newer docker releases:
src/github.com/calavera/docker-volume-glusterfs/main.go:38: cannot use d (type glusterfsDriver) as type volume.Driver in argument to volume.NewHandler:
glusterfsDriver does not implement volume.Driver (missing Capabilities method)

It adds a basic implementation of the Capabilities function which is needed in the newer docker releases. I successfully tested it with CentOS 7 (Atomic) and Fedora 23.
